### PR TITLE
Fix an issue causing eraser paths to use currentPathProperty

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter6_graphics/Tutorial6_4_2DrawWithTouch2.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter6_graphics/Tutorial6_4_2DrawWithTouch2.kt
@@ -233,9 +233,9 @@ private fun DrawingApp() {
                             color = Color.Transparent,
                             path = path,
                             style = Stroke(
-                                width = currentPathProperty.strokeWidth,
-                                cap = currentPathProperty.strokeCap,
-                                join = currentPathProperty.strokeJoin
+                                width = property.strokeWidth,
+                                cap = property.strokeCap,
+                                join = property.strokeJoin
                             ),
                             blendMode = BlendMode.Clear
                         )


### PR DESCRIPTION
First of all, thanks for the excellent repository. I have been learning a lot from it.

While using the DrawingApp, I noticed that when I draw something, then erase part of it, then click on the brush to change current path properties the erased part will change on canvas. After checking the code, I noticed that eraser paths always used current path properties and discarded their properties causing this behavior.

