### PR TITLE
Fix issue #26 - Tutorial 2.4 Preview Broken

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/Utils.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/Utils.kt
@@ -1,0 +1,8 @@
+package com.smarttoolfactory.tutorial1_1basics
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.platform.LocalInspectionMode
+
+@Stable
+val isInPreview @Composable get() = LocalInspectionMode.current

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_4Image.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_4Image.kt
@@ -63,13 +63,14 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.smarttoolfactory.tutorial1_1basics.R
+import com.smarttoolfactory.tutorial1_1basics.isInPreview
 import com.smarttoolfactory.tutorial1_1basics.ui.components.FullWidthColumn
 import com.smarttoolfactory.tutorial1_1basics.ui.components.FullWidthRow
 import com.smarttoolfactory.tutorial1_1basics.ui.components.StyleableTutorialText
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialHeader
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialText2
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_4Screen() {
     TutorialContent()
@@ -128,7 +129,10 @@ private fun TutorialContent() {
                         "set it to Image component."
             )
 
-            ImageDownloadWithGlideExample()
+            // Previews rendered within Android Studio cannot access Network to load images. Skipping this Composable while rendering Preview.
+            if (!isInPreview) {
+                ImageDownloadWithGlideExample()
+            }
 
             StyleableTutorialText(
                 text = "8) Use Coil library to fetch an image resource from network and " +


### PR DESCRIPTION

### Before
<img width="222" alt="Screenshot 2024-02-27 at 10 49 35 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/9493b3b3-e6e5-4fca-bfaa-72c8f781315b">

### After
<img width="326" alt="Screenshot 2024-02-27 at 10 50 37 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/9289499e-abc3-4c5d-9374-e87a8dc0b46d">