### PR TITLE
Show background in Previews for better visibility

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter1_basics/Tutorial1_1ColumnRowBoxScreen.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter1_basics/Tutorial1_1ColumnRowBoxScreen.kt
@@ -45,10 +45,9 @@ import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialText2
  * Order of modifiers matter. Depending on which order **padding** is added
  * it makes UI component(Compose) to have either margin or padding.
  */
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial1_1Screen() {
-
     TutorialContent()
 }
 
@@ -511,9 +510,9 @@ fun WeightAndSpacerExample() {
     Spacer(modifier = Modifier.height(16.dp))
 }
 
-@Preview
+@Preview(showBackground = true)
 @Preview("dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Preview(device = Devices.PIXEL_C)
+@Preview(device = Devices.PIXEL_C, showBackground = true)
 @Composable
 private fun Tutorial1_1Preview() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/ConstraintLayoutSample.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/ConstraintLayoutSample.kt
@@ -28,7 +28,7 @@ import androidx.constraintlayout.compose.Dimension
 import androidx.constraintlayout.compose.layoutId
 
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun DecoupledConstraintLayout() {
     BoxWithConstraints {
@@ -65,7 +65,7 @@ private fun decoupledConstraints(margin: Dp): ConstraintSet {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ConstraintLayoutGuidlineSample() {
     ConstraintLayout(
@@ -104,7 +104,7 @@ private fun ConstraintLayoutGuidlineSample() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun ConstraintLayoutDemo() {
     ConstraintLayout(modifier = Modifier.size(200.dp)) {
@@ -143,7 +143,7 @@ fun ConstraintLayoutDemo() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ConstraintLayoutAnimationTest() {
 

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_3BottomDrawer.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_3BottomDrawer.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_10Screen3() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_11SnackProgressSelection.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_11SnackProgressSelection.kt
@@ -60,7 +60,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 
 @ExperimentalMaterialApi
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_11Screen() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_12AlertDialog.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_12AlertDialog.kt
@@ -60,7 +60,7 @@ import com.smarttoolfactory.tutorial1_1basics.ui.components.StyleableTutorialTex
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialHeader
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialText2
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_12Screen() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_14LazyColumnWithCheckBox.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_14LazyColumnWithCheckBox.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 
 @ExperimentalMaterialApi
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_14Screen() {
     val taskViewModel = TaskViewModel()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_15ChipAndTextLayout.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_15ChipAndTextLayout.kt
@@ -77,7 +77,7 @@ data class ChipData(
     val id: String = UUID.randomUUID().toString()
 )
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ChipSampleAndTextLayoutSample() {
 

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_1Text.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_1Text.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.unit.sp
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialHeader
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialText2
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_1Screen() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_2Button.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_2Button.kt
@@ -68,7 +68,7 @@ import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialChip
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialHeader
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialText2
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_2Screen() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_3TextField.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_3TextField.kt
@@ -66,7 +66,7 @@ import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialText2
  * As of 1.0.1 it does not have Assistive Text, Error Text, Character Counter,
  * Prefix, and Suffix.
  */
-@Preview
+@Preview(showBackground = true)
 @ExperimentalComposeUiApi
 @Composable
 fun Tutorial2_3Screen() {
@@ -656,7 +656,7 @@ fun creditCardFilter(text: AnnotatedString): TransformedText {
  * A sample for displaying label, placeholder and clickability with enabled or and readOnly
  * param variations
  */
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TextFieldDisableTest() {
     var value by remember {

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_5_2LazyColumn2.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_5_2LazyColumn2.kt
@@ -23,7 +23,7 @@ import com.smarttoolfactory.tutorial1_1basics.ui.components.FullWidthRow
 import com.smarttoolfactory.tutorial1_1basics.ui.components.SnackCard
 import kotlinx.coroutines.launch
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_5Screen2() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_5_7ListItem.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_5_7ListItem.kt
@@ -28,7 +28,7 @@ import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialHeader
 import com.smarttoolfactory.tutorial1_1basics.ui.components.TutorialText2
 
 @ExperimentalMaterialApi
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_5Screen7() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_5_8LazyListLayoutInfo.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_5_8LazyListLayoutInfo.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.smarttoolfactory.tutorial1_1basics.ui.components.StyleableTutorialText
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_5Screen8() {
     TutorialContent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_6_1TopAppBar.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_6_1TopAppBar.kt
@@ -359,9 +359,9 @@ fun ActionMenu(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Preview("dark", uiMode = UI_MODE_NIGHT_YES)
-@Preview(device = Devices.PIXEL_C)
+@Preview(device = Devices.PIXEL_C, showBackground = true)
 @Composable
 private fun ActionMenuReview() {
     val items = listOf(

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
@@ -193,9 +193,9 @@ fun AppDrawer(
     }
 }
 
-@Preview
-@Preview("dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Preview(device = Devices.PIXEL_C)
+@Preview(showBackground = true)
+@Preview("dark", uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Preview(device = Devices.PIXEL_C, showBackground = true)
 @Composable
 private fun AppDrawerPreview() {
     ComposeTutorialsTheme {

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_2ModalDrawer.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_2ModalDrawer.kt
@@ -55,7 +55,7 @@ import com.smarttoolfactory.tutorial1_1basics.ui.components.DrawerButton
 import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun Tutorial2_9Screen2() {
     TutorialContent()


### PR DESCRIPTION
PR adds `showBackground` flag for Previews in Tutorial 1 and 2.

### Before and After
<img width="332" alt="Screenshot 2024-02-27 at 11 42 20 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/ab2666cd-7889-43da-a9da-c5aff12224b4"> <img width="332" alt="Screenshot 2024-02-27 at 11 42 35 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/67e06629-4fcc-41b9-9bc1-a0b9fb9231c0">
