### PR TITLE
Provide BottomSheetStates via PreviewProvider

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.smarttoolfactory.tutorial1_1basics.model.places
@@ -54,13 +56,12 @@ fun Tutorial2_10Screen1() {
 @ExperimentalAnimationApi
 @ExperimentalMaterialApi
 @Composable
-private fun TutorialContent() {
-
+private fun TutorialContent(initialState: BottomSheetValue = BottomSheetValue.Collapsed) {
     val context = LocalContext.current
 
     val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(
         bottomSheetState = rememberBottomSheetState(
-            initialValue = BottomSheetValue.Collapsed,
+            initialValue = initialState,
             confirmStateChange = { bottomSheetValue: BottomSheetValue ->
                 // This callback gets called twice in Jetpack Compose version 1.5.4
                 println("State changed to $bottomSheetValue")
@@ -209,13 +210,23 @@ private fun FloatingActionButtonComponentPreview() {
 @ExperimentalAnimationApi
 @ExperimentalMaterialApi
 @Preview
-@Preview("dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Preview(device = Devices.PIXEL_C)
 @Composable
-private fun TutorialContentPreview() {
+private fun TutorialContentPreview(
+    @PreviewParameter(BottomSheetStateProvider::class)
+    state: BottomSheetValue
+) {
     ComposeTutorialsTheme {
-        TutorialContent()
+        TutorialContent(initialState = state)
     }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+private class BottomSheetStateProvider : PreviewParameterProvider<BottomSheetValue> {
+    override val values: Sequence<BottomSheetValue>
+        get() = sequenceOf(
+            BottomSheetValue.Collapsed,
+            BottomSheetValue.Expanded
+        )
 }
 
 @ExperimentalAnimationApi


### PR DESCRIPTION
Current Preview only shows `BottomSheetValue.Collapsed` state as that is hard coded as the `initialValue`.
Hoisted this state up to caller and provided via `PreviewParameterProvider` interface for `@Preview`.

### Before
<img width="263" alt="Screenshot 2024-02-29 at 10 22 00 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/4e5f60a8-7683-4729-9518-f1f6daae98c5">


### After

<img width="542" alt="Screenshot 2024-02-29 at 10 12 13 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/e04ce319-2e29-40ff-a946-ba87ccd6455a">
