### PR TITLE
Fix bottom sheet not closing in previews & rotate icon based on bottom sheet.

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -157,7 +158,10 @@ private fun FloatingActionButtonComponent(
         },
         backgroundColor = Color(0xffFFA000)
     ) {
-        Icon(Icons.Filled.Navigation, tint = Color.White, contentDescription = "Icon Rotation", modifier = Modifier.rotate(iconRotation))
+        Icon(
+            imageVector = Icons.Filled.Navigation, tint = Color.White,
+            contentDescription = "Icon Rotation", modifier = Modifier.graphicsLayer { this.rotationZ = iconRotation }
+        )
     }
 }
 

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
@@ -3,6 +3,8 @@ package com.smarttoolfactory.tutorial1_1basics.chapter2_material_widgets
 import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -28,8 +30,10 @@ import androidx.compose.material.icons.filled.Navigation
 import androidx.compose.material.rememberBottomSheetScaffoldState
 import androidx.compose.material.rememberBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -38,6 +42,7 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.smarttoolfactory.tutorial1_1basics.isInPreview
 import com.smarttoolfactory.tutorial1_1basics.model.places
 import com.smarttoolfactory.tutorial1_1basics.ui.ComposeTutorialsTheme
 import com.smarttoolfactory.tutorial1_1basics.ui.components.PlacesToBookVerticalComponent
@@ -57,6 +62,7 @@ fun Tutorial2_10Screen1() {
 private fun TutorialContent() {
 
     val context = LocalContext.current
+    val isInPreview = isInPreview
 
     val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(
         bottomSheetState = rememberBottomSheetState(
@@ -64,11 +70,9 @@ private fun TutorialContent() {
             confirmStateChange = { bottomSheetValue: BottomSheetValue ->
                 // This callback gets called twice in Jetpack Compose version 1.5.4
                 println("State changed to $bottomSheetValue")
-                Toast.makeText(
-                    context,
-                    "State changed to $bottomSheetValue",
-                    Toast.LENGTH_SHORT
-                ).show()
+                if(!isInPreview) {
+                    Toast.makeText(context, "State changed to $bottomSheetValue", Toast.LENGTH_SHORT).show()
+                }
                 true
             }
         )
@@ -139,6 +143,8 @@ private fun FloatingActionButtonComponent(
     bottomSheetState: BottomSheetState
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val iconRotation by animateFloatAsState(targetValue = if (bottomSheetState.isCollapsed) 0f else 180f, label = "Icon Rotation Anim", animationSpec = tween())
+
     FloatingActionButton(
         onClick = {
             coroutineScope.launch {
@@ -151,10 +157,7 @@ private fun FloatingActionButtonComponent(
         },
         backgroundColor = Color(0xffFFA000)
     ) {
-        Icon(
-            Icons.Filled.Navigation, tint = Color.White,
-            contentDescription = null
-        )
+        Icon(Icons.Filled.Navigation, tint = Color.White, contentDescription = "Icon Rotation", modifier = Modifier.rotate(iconRotation))
     }
 }
 


### PR DESCRIPTION
### Floating Action State Based on Bottom sheet State
| Before  | After |
| :-: | :-:|
| <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/a55e72e4-a5e7-4f32-8565-a342e520cc48" width="400"/> | <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/b2d49aec-0131-4495-9a8c-e01f57d4e933" width="400" /> |

### Bottom Sheet Intractive Mode Issue

Previews for Bottom sheet in intractive mode are not Working as expected as we are using the Toast in confirmStateChange of bottom sheet. We can skip the Toast using isInPreview. 
```
if(!isInPreview) {
  Toast.makeText(context, "State changed to $bottomSheetValue", Toast.LENGTH_SHORT).show()
}
```

### Icon Rotation Animation
https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/0d07db1e-efe7-4d28-8fd2-b6b75e0944b0

