### PR TITLE
Bubble - Fix Unnecessary use of composed Modifier and added Preview

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter3_layout/Bubble.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter3_layout/Bubble.kt
@@ -1,8 +1,16 @@
 package com.smarttoolfactory.tutorial1_1basics.chapter3_layout
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.GenericShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
@@ -14,13 +22,44 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
+import androidx.compose.ui.unit.sp
+import com.smarttoolfactory.tutorial1_1basics.ui.ComposeTutorialsTheme
+import com.smarttoolfactory.tutorial1_1basics.ui.SentMessageColor
 
+@Preview
+@Composable
+private fun BubblePreview() {
+    ComposeTutorialsTheme {
+        Box(
+            modifier = Modifier
+                .height(40.dp)
+                .drawBubble(
+                    arrowWidth = 16.dp,
+                    arrowHeight = 16.dp,
+                    arrowOffset = 5.dp,
+                    arrowDirection = ArrowDirection.Left,
+                    elevation = 2.dp,
+                    color = SentMessageColor
+                )
+                .padding(horizontal = 16.dp),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            Text(
+                text = "Hello World!",
+                fontSize = 18.sp
+            )
+        }
+    }
+}
+
+@Composable
 fun Modifier.drawBubble(
     arrowWidth: Dp,
     arrowHeight: Dp,
@@ -28,7 +67,7 @@ fun Modifier.drawBubble(
     arrowDirection: ArrowDirection,
     elevation: Dp = 0.dp,
     color: Color = Color.Unspecified
-) = composed {
+): Modifier {
 
     val arrowWidthPx: Float
     val arrowHeightPx: Float
@@ -44,7 +83,7 @@ fun Modifier.drawBubble(
         createBubbleShape(arrowWidthPx, arrowHeightPx, arrowOffsetPx, arrowDirection)
     }
 
-    Modifier
+    val newModifier = Modifier
         .then(
             if (elevation > 0.dp) {
                 Modifier.shadow(
@@ -105,6 +144,8 @@ fun Modifier.drawBubble(
         }
     // 🔥 This border is applied after new layout which is area that is reserved after arrow
     // .border(2.dp, Color.Magenta)
+
+    return this then newModifier
 }
 
 fun createBubbleShape(


### PR DESCRIPTION
### Warning

<img width="915" alt="Screenshot 2024-03-03 at 10 32 42 AM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/f0c9b937-19f5-4b49-8755-85ba812618ab">

Fix is inspired by this [Stack Overflow thread](https://stackoverflow.com/a/65084372/12915312).

### Preview
Added a Preview for `Modifier.drawBubble()` usage.

<img width="275" alt="Screenshot 2024-03-03 at 10 33 04 AM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/532d226a-0cf9-46ee-b69d-b9ae7e414afa">

