### PR TITLE
[UPDATE]- kotlinCompilerExtensionVersion update.

### DIFF
--- a/Tutorial2-1Unit-Testing/build.gradle.kts
+++ b/Tutorial2-1Unit-Testing/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
+        kotlinCompilerExtensionVersion = "1.5.10"
     }
     packagingOptions {
         resources {

--- a/Tutorial2-2UI-Testing/build.gradle.kts
+++ b/Tutorial2-2UI-Testing/build.gradle.kts
@@ -40,7 +40,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
+        kotlinCompilerExtensionVersion = "1.5.10"
     }
     packaging {
         resources {


### PR DESCRIPTION
**Error Message :** 

This version (1.5.3) of the Compose Compiler requires Kotlin version 1.9.10 but you appear to be using Kotlin version 1.9.22 which is not known to be compatible.  Please consult the Compose-Kotlin compatibility map located at https://developer.android.com/jetpack/androidx/releases/compose-kotlin to choose a compatible version pair (or `suppressKotlinVersionCompatibilityCheck` but don't say I didn't warn you!).

**Platform :** 

Android Studio Jellyfish | 2023.3.1 Canary 12

**Revision**

kotlinCompilerExtensionVersion version update. // FIXED
