### PR TITLE
Tutorial 2.9 - Preview Drawer States (Open and Closed)

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
@@ -60,7 +60,13 @@ import kotlinx.coroutines.launch
 
 @Preview
 @Composable
-fun Tutorial2_9Screen1(
+fun Tutorial2_9Screen1() {
+    TutorialContent()
+}
+
+@Preview
+@Composable
+private fun PreviewTutorialContent(
     @PreviewParameter(DrawerStateProvider::class)
     drawerValue: DrawerValue
 ) {

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
@@ -13,9 +13,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.DrawerValue
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
+import androidx.compose.material.ScaffoldState
 import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Text
@@ -25,6 +27,7 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Message
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.rememberDrawerState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -42,33 +45,51 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.smarttoolfactory.tutorial1_1basics.R
+import com.smarttoolfactory.tutorial1_1basics.isInPreview
 import com.smarttoolfactory.tutorial1_1basics.ui.ComposeTutorialsTheme
 import com.smarttoolfactory.tutorial1_1basics.ui.components.DrawerButton
 import kotlinx.coroutines.launch
 
 @Preview
 @Composable
-fun Tutorial2_9Screen1() {
-    TutorialContent()
+fun Tutorial2_9Screen1(
+    @PreviewParameter(DrawerStateProvider::class)
+    drawerValue: DrawerValue
+) {
+    TutorialContent(
+        scaffoldState = rememberScaffoldState(
+            drawerState = rememberDrawerState(initialValue = drawerValue)
+        )
+    )
+}
+
+private class DrawerStateProvider: PreviewParameterProvider<DrawerValue> {
+    override val values: Sequence<DrawerValue>
+        get() = sequenceOf(
+            DrawerValue.Closed,
+            DrawerValue.Open
+        )
 }
 
 @Composable
-private fun TutorialContent() {
+private fun TutorialContent(scaffoldState: ScaffoldState = rememberScaffoldState()) {
 
     var currentRoute by remember { mutableStateOf(Routes.HOME_ROUTE) }
-    val scaffoldState = rememberScaffoldState()
     val navController = rememberNavController()
     val coroutineScope = rememberCoroutineScope()
     val openDrawer: () -> Unit = { coroutineScope.launch { scaffoldState.drawerState.open() } }
     val closeDrawer: () -> Unit = { coroutineScope.launch { scaffoldState.drawerState.close() } }
 
     val context = LocalContext.current
+    val isInPreview = isInPreview
 
     Scaffold(
         scaffoldState = scaffoldState,
@@ -123,13 +144,11 @@ private fun TutorialContent() {
                         Text(text = "Action",
                             modifier = Modifier
                                 .clickable {
-                                    Toast
-                                        .makeText(
-                                            context,
-                                            "Action invoked",
-                                            Toast.LENGTH_SHORT
-                                        )
-                                        .show()
+                                    if (!isInPreview) {
+                                        Toast
+                                            .makeText(context, "Action invoked", Toast.LENGTH_SHORT)
+                                            .show()
+                                    }
                                 }
                                 .padding(4.dp)
                         )

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
@@ -77,7 +77,7 @@ private fun PreviewTutorialContent(
     )
 }
 
-private class DrawerStateProvider: PreviewParameterProvider<DrawerValue> {
+class DrawerStateProvider: PreviewParameterProvider<DrawerValue> {
     override val values: Sequence<DrawerValue>
         get() = sequenceOf(
             DrawerValue.Closed,
@@ -163,10 +163,11 @@ private fun TutorialContent(scaffoldState: ScaffoldState = rememberScaffoldState
                 }
             }
         }
-    ) {
+    ) { contentPadding ->
         NavHost(
             navController = navController,
-            startDestination = Routes.HOME_ROUTE
+            startDestination = Routes.HOME_ROUTE,
+            modifier = Modifier.padding(contentPadding)
         ) {
             composable(Routes.HOME_ROUTE) {
                 HomeComponent()

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_2ModalDrawer.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_2ModalDrawer.kt
@@ -48,14 +48,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.smarttoolfactory.tutorial1_1basics.R
 import com.smarttoolfactory.tutorial1_1basics.ui.components.DrawerButton
 import kotlinx.coroutines.launch
 
-@ExperimentalMaterialApi
-@Preview(showBackground = true)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun Tutorial2_9Screen2() {
     TutorialContent()
@@ -68,9 +68,19 @@ private fun TutorialContent() {
 }
 
 @ExperimentalMaterialApi
+@Preview(showBackground = true)
 @Composable
-private fun ModalDrawerComponent() {
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
+private fun ModalDrawerPreview(
+    @PreviewParameter(DrawerStateProvider::class)
+    drawerValue: DrawerValue
+) {
+    ModalDrawerComponent(drawerValue = drawerValue)
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun ModalDrawerComponent(drawerValue: DrawerValue = DrawerValue.Closed) {
+    val drawerState = rememberDrawerState(initialValue = drawerValue)
     val coroutineScope = rememberCoroutineScope()
     val openDrawer: () -> Unit = { coroutineScope.launch { drawerState.open() } }
     val closeDrawer: () -> Unit = { coroutineScope.launch { drawerState.close() } }

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_3ModalDrawerScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_3ModalDrawerScaffold.kt
@@ -2,6 +2,7 @@ package com.smarttoolfactory.tutorial1_1basics.chapter2_material_widgets
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.material.Divider
 import androidx.compose.material.DrawerValue
@@ -11,17 +12,17 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
-@Preview
 @Composable
 fun Tutorial2_9Screen3() {
     TutorialContent()
@@ -34,21 +35,31 @@ private fun TutorialContent() {
 }
 
 @ExperimentalMaterialApi
+@Preview(showBackground = true)
 @Composable
-private fun ModalDrawerComponent() {
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
+private fun ModalDrawerPreview(
+    @PreviewParameter(DrawerStateProvider::class)
+    drawerValue: DrawerValue
+) {
+    ModalDrawerComponent(drawerValue = drawerValue)
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun ModalDrawerComponent(drawerValue: DrawerValue = DrawerValue.Closed) {
+    val drawerState = rememberDrawerState(drawerValue)
     val coroutineScope = rememberCoroutineScope()
     val openDrawer: () -> Unit = { coroutineScope.launch { drawerState.open() } }
     val closeDrawer: () -> Unit = { coroutineScope.launch { drawerState.close() } }
-    var selectedIndex by remember { mutableStateOf(0) }
+    var selectedIndex by remember { mutableIntStateOf(0) }
 
     Scaffold(
         topBar = {
             ModalDrawerTopAppBar(openDrawer)
         },
-
-        ) {
+    ) { contentPadding ->
         ModalDrawer(
+            modifier = Modifier.padding(contentPadding),
             drawerElevation = 24.dp,
             drawerShape = CutCornerShape(topEnd = 24.dp),
             drawerState = drawerState,
@@ -67,9 +78,7 @@ private fun ModalDrawerComponent() {
                 Column(modifier = Modifier.fillMaxSize()) {
                     ModalContent(openDrawer)
                 }
-
             }
         )
     }
-
 }

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_4ModalDrawerScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_4ModalDrawerScaffold.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -19,11 +20,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
-@Preview
 @Composable
 fun Tutorial2_9Screen4() {
     TutorialContent()
@@ -36,13 +37,23 @@ private fun TutorialContent() {
 }
 
 @ExperimentalMaterialApi
+@Preview(showBackground = true)
 @Composable
-private fun ModalDrawerComponent() {
-    val drawerState = rememberDrawerState(DrawerValue.Closed)
+private fun ModalDrawerPreview(
+    @PreviewParameter(DrawerStateProvider::class)
+    drawerValue: DrawerValue
+) {
+    ModalDrawerComponent(drawerValue = drawerValue)
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun ModalDrawerComponent(drawerValue: DrawerValue = DrawerValue.Closed) {
+    val drawerState = rememberDrawerState(drawerValue)
     val coroutineScope = rememberCoroutineScope()
     val openDrawer: () -> Unit = { coroutineScope.launch { drawerState.open() } }
     val closeDrawer: () -> Unit = { coroutineScope.launch { drawerState.close() } }
-    var selectedIndex by remember { mutableStateOf(0) }
+    var selectedIndex by remember { mutableIntStateOf(0) }
 
     ModalDrawer(
         drawerState = drawerState,
@@ -62,10 +73,12 @@ private fun ModalDrawerComponent() {
             Scaffold(
                 topBar = {
                     ModalDrawerTopAppBar(openDrawer)
-                }) {
+                }
+            ) { contentPadding ->
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
+                        .padding(contentPadding)
                         .padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {


### PR DESCRIPTION
- Added Previews for different initial `DrawerValue`
- Fixed Preview becoming non-interactive when a toast was triggered in Preview

### Before
<img width="276" alt="Screenshot 2024-03-05 at 7 58 32 AM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/c984b806-1028-4dbf-9b2b-f23ad7628bc1">

### After
<img width="538" alt="Screenshot 2024-03-05 at 7 59 25 AM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/bb850674-3ec5-489e-9e02-29c14768044d">
