### PR TITLE
Tutorial 2.9.1 - Fix "Content padding parameter it not" used issue

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_9_1SideNavigationScaffold.kt
@@ -138,10 +138,11 @@ private fun TutorialContent() {
                 }
             }
         }
-    ) {
+    ) { paddingValues ->
         NavHost(
             navController = navController,
-            startDestination = Routes.HOME_ROUTE
+            startDestination = Routes.HOME_ROUTE,
+            modifier = Modifier.padding(paddingValues)
         ) {
             composable(Routes.HOME_ROUTE) {
                 HomeComponent()


### PR DESCRIPTION
**It's required to use padding parameter, passed into Scaffold content composable.**
Solution inspired by this [Stack Overflow answer](https://stackoverflow.com/a/72085218/12915312).


<img width="876" alt="Screenshot 2024-03-05 at 8 39 00 AM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/2d8d6a9d-a030-4407-b272-b87ad83a854c">