### PR TITLE
Tutorial 2.10.1 - Fix Broken Preview

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_1BottomSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
@@ -109,7 +110,11 @@ private fun TutorialContent(initialState: BottomSheetValue = BottomSheetValue.Co
 private fun MainContent(bottomSheetState: BottomSheetState) {
 
     val currentValue: BottomSheetValue = bottomSheetState.currentValue
-    val offset = bottomSheetState.requireOffset()
+    val offset = try {
+        bottomSheetState.requireOffset()
+    } catch (e: Exception) {
+        Offset.Zero
+    }
 
     val progress = bottomSheetState.progress
 


### PR DESCRIPTION
Preview was crashing with exception
```
java.lang.IllegalStateException: The offset was read before being initialized. Did you access the offset in a phase before layout, like effects or composition?
	at androidx.compose.material.AnchoredDraggableState.requireOffset(AnchoredDraggable.kt:344)
	at androidx.compose.material.BottomSheetState.requireOffset(BottomSheetScaffold.kt:230)
	at com.smarttoolfactory.tutorial1_1basics.chapter2_material_widgets.Tutorial2_10_1BottomSheetKt.MainContent(Tutorial2_10_1BottomSheet.kt:115)
```

Defaulted to `Offset.Zero` if `BottomSheetState.offset` was not initialized by the time it was read in Preview.

<img width="278" alt="Screenshot 2024-03-05 at 10 17 11 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/5e472f54-ce0d-419f-adc6-30449d6bc26a">
