### PR TITLE
Tutorial 2.10 - Previews for different Bottom Sheet States

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_2ModalBottomSheetLayout.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_2ModalBottomSheetLayout.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.smarttoolfactory.tutorial1_1basics.R
@@ -34,16 +36,37 @@ fun Tutorial2_10Screen2() {
     TutorialContent()
 }
 
+@OptIn(ExperimentalAnimationApi::class)
+@ExperimentalMaterialApi
+@Preview
+@Composable
+private fun TutorialContentPreview(
+    @PreviewParameter(ModalBottomSheetValueProvider::class)
+    initialModalBottomSheetValue: ModalBottomSheetValue
+) {
+    TutorialContent(initialModalBottomSheetValue)
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+class ModalBottomSheetValueProvider : PreviewParameterProvider<ModalBottomSheetValue> {
+    override val values: Sequence<ModalBottomSheetValue>
+        get() = sequenceOf(
+            ModalBottomSheetValue.Hidden,
+            ModalBottomSheetValue.HalfExpanded,
+            ModalBottomSheetValue.Expanded
+        )
+}
+
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @ExperimentalAnimationApi
 @ExperimentalMaterialApi
 @Composable
-private fun TutorialContent() {
+private fun TutorialContent(initialModalBottomSheetValue: ModalBottomSheetValue = ModalBottomSheetValue.HalfExpanded) {
 
     val modalBottomSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.HalfExpanded,
+        initialValue = initialModalBottomSheetValue,
         skipHalfExpanded = false,
-        confirmValueChange = { modalBottomSheetValue: ModalBottomSheetValue ->
+        confirmValueChange = { _: ModalBottomSheetValue ->
             true
         }
     )

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_3BottomDrawer.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_3BottomDrawer.kt
@@ -25,9 +25,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterialApi::class)
 @Preview(showBackground = true)
 @Composable
 fun Tutorial2_10Screen3() {
@@ -35,8 +38,28 @@ fun Tutorial2_10Screen3() {
 }
 
 @OptIn(ExperimentalMaterialApi::class)
+@Preview(showBackground = true)
 @Composable
-private fun TutorialContent() {
+private fun TutorialContentPreview(
+    @PreviewParameter(BottomDrawerValueProvider::class)
+    initialBottomDrawerValue: BottomDrawerValue
+) {
+    TutorialContent(initialBottomDrawerValue)
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+class BottomDrawerValueProvider : PreviewParameterProvider<BottomDrawerValue> {
+    override val values: Sequence<BottomDrawerValue>
+        get() = sequenceOf(
+            BottomDrawerValue.Closed,
+            BottomDrawerValue.Open,
+            BottomDrawerValue.Expanded
+        )
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun TutorialContent(initialBottomDrawerValue: BottomDrawerValue = BottomDrawerValue.Closed) {
     val (gesturesEnabled, toggleGesturesEnabled) = remember { mutableStateOf(true) }
     val scope = rememberCoroutineScope()
     Column {
@@ -52,8 +75,8 @@ private fun TutorialContent() {
             Text(text = if (gesturesEnabled) "Gestures Enabled" else "Gestures Disabled")
         }
         val drawerState = rememberBottomDrawerState(
-            initialValue = BottomDrawerValue.Closed,
-            confirmStateChange = { bottomDrawerValue: BottomDrawerValue ->
+            initialValue = initialBottomDrawerValue,
+            confirmStateChange = { _: BottomDrawerValue ->
                 true
             }
         )
@@ -89,7 +112,9 @@ private fun TutorialContent() {
             },
             content = {
                 Column(
-                    modifier = Modifier.fillMaxSize().padding(16.dp),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     val openText = if (gesturesEnabled) "▲▲▲ Pull up ▲▲▲" else "Click the button!"

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_4BottomDrawer2.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_4BottomDrawer2.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -68,11 +70,30 @@ fun Tutorial2_10Screen4() {
 }
 
 @ExperimentalMaterialApi
+@Preview
 @Composable
-private fun TutorialContent() {
+private fun TutorialContentPreview(
+    @PreviewParameter(BottomDrawerValueProvider::class)
+    initialBottomDrawerValue: BottomDrawerValue
+) {
+    TutorialContent(initialBottomDrawerValue)
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+private class BottomDrawerValueProvider : PreviewParameterProvider<BottomDrawerValue> {
+    override val values: Sequence<BottomDrawerValue>
+        get() = sequenceOf(
+            BottomDrawerValue.Closed,
+            BottomDrawerValue.Expanded
+        )
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun TutorialContent(initialBottomDrawerValue: BottomDrawerValue = BottomDrawerValue.Closed) {
 
     val coroutineScope = rememberCoroutineScope()
-    val drawerState: BottomDrawerState = rememberBottomDrawerState(BottomDrawerValue.Closed)
+    val drawerState: BottomDrawerState = rememberBottomDrawerState(initialValue = initialBottomDrawerValue)
     val openDrawer: () -> Unit = { coroutineScope.launch { drawerState.expand() } }
     val closeDrawer: () -> Unit = { coroutineScope.launch { drawerState.close() } }
     var selectedBottomDrawerIndex by remember { mutableStateOf(0) }

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_5BackdropScaffold.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_10_5BackdropScaffold.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.smarttoolfactory.tutorial1_1basics.model.places
 import com.smarttoolfactory.tutorial1_1basics.ui.components.PlacesToBookVerticalComponent
@@ -82,13 +84,33 @@ fun Tutorial2_10Screen5() {
     TutorialContent()
 }
 
+@OptIn(ExperimentalAnimationApi::class)
+@ExperimentalMaterialApi
+@Preview
+@Composable
+private fun TutorialContentPreview(
+    @PreviewParameter(BackdropValueProvider::class)
+    initialBackdropValue: BackdropValue
+) {
+    TutorialContent(initialBackdropValue)
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+private class BackdropValueProvider : PreviewParameterProvider<BackdropValue> {
+    override val values: Sequence<BackdropValue>
+        get() = sequenceOf(
+            BackdropValue.Concealed,
+            BackdropValue.Revealed
+        )
+}
+
 @ExperimentalAnimationApi
 @ExperimentalMaterialApi
 @Composable
-private fun TutorialContent() {
+private fun TutorialContent(initialBackdropValue: BackdropValue = BackdropValue.Revealed) {
 
     val backdropScaffoldState =
-        rememberBackdropScaffoldState(initialValue = BackdropValue.Revealed)
+        rememberBackdropScaffoldState(initialValue = initialBackdropValue)
     val coroutineScope = rememberCoroutineScope()
 
     BackdropScaffold(


### PR DESCRIPTION
### Tutorial 2.10.2

<img width="957" alt="2 10 2" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/84caf1f3-7a4e-463f-9f16-5188417ac5ba">


### Tutorial 2.10.3
<img width="961" alt="2 10 3" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/1b9ed1c6-d798-4780-96a5-8c9f3abcd2f0">


### Tutorial 2.10.4
<img width="582" alt="2 10 4" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/2c669e27-2d3e-4809-822e-214d48428124">


### Tutorial 2.10.5
<img width="649" alt="2 10 5" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/886c8b5e-2e8c-4152-8b93-44d093494d55">
