### PR TITLE
Tutorial 3.6.1 - Restrict ChatTextField() max lines

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter3_layout/Tutorial3_6_1CustomFlexLayout.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter3_layout/Tutorial3_6_1CustomFlexLayout.kt
@@ -34,6 +34,7 @@ import com.smarttoolfactory.tutorial1_1basics.chapter3_layout.chat.ChatMessage
 import com.smarttoolfactory.tutorial1_1basics.chapter3_layout.chat.MessageStatus
 import com.smarttoolfactory.tutorial1_1basics.chapter3_layout.chat.MessageTimeText
 import com.smarttoolfactory.tutorial1_1basics.chapter3_layout.chat.widget.ChatFlexBoxLayout
+import com.smarttoolfactory.tutorial1_1basics.isInPreview
 import com.smarttoolfactory.tutorial1_1basics.ui.Blue400
 import com.smarttoolfactory.tutorial1_1basics.ui.Green400
 import com.smarttoolfactory.tutorial1_1basics.ui.Orange400
@@ -70,6 +71,7 @@ private fun TutorialContent() {
     val messages = remember { mutableStateListOf<ChatMessage>() }
     val sdf = remember { SimpleDateFormat("hh:mm a", Locale.ROOT) }
     val context = LocalContext.current
+    val isInPreview = isInPreview
 
     println("🎃 Tutorial3_6Screen messages: $messages, sdf: $sdf")
 
@@ -86,7 +88,9 @@ private fun TutorialContent() {
             title = "Flexible ChatRows",
             description = description,
             onClick = {
-                Toast.makeText(context, description, Toast.LENGTH_SHORT).show()
+                if (!isInPreview) {
+                    Toast.makeText(context, description, Toast.LENGTH_SHORT).show()
+                }
             }
         )
 
@@ -99,7 +103,7 @@ private fun TutorialContent() {
             items(messages) { message: ChatMessage ->
 
                 // Remember random stats icon to not create in every recomposition
-                val messageStatus = remember { MessageStatus.values()[Random.nextInt(3)] }
+                val messageStatus = remember { MessageStatus.entries[Random.nextInt(3)] }
 
 
                 Column(

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter3_layout/chat/ChatInput.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter3_layout/chat/ChatInput.kt
@@ -29,7 +29,7 @@ import com.smarttoolfactory.tutorial1_1basics.ui.IndicatingIconButton
 internal fun ChatInput(modifier: Modifier = Modifier, onMessageChange: (String) -> Unit) {
 
     var input by remember { mutableStateOf(TextFieldValue("")) }
-    val textEmpty: Boolean by derivedStateOf { input.text.isEmpty() }
+    val textEmpty: Boolean by remember { derivedStateOf { input.text.isEmpty() } }
 
     Row(
         modifier = modifier
@@ -114,6 +114,7 @@ private fun ChatTextField(
                         ),
                         value = input,
                         onValueChange = onValueChange,
+                        maxLines = 6,
                         cursorBrush = SolidColor(Color(0xff00897B)),
                         decorationBox = { innerTextField ->
                             if (empty) {


### PR DESCRIPTION
- Restricted max lines for `ChatTextField()` to **6** as it gets bigger with input. Limiting this to **6** would let it get big to a certain limit and then allow user to scroll to see input content (feels more practical).

### Before

<img width="326" alt="Screenshot 2024-03-07 at 8 26 01 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/481b267d-057c-471c-8857-0c67dc02524c">

### After
<img width="326" alt="Screenshot 2024-03-07 at 8 26 36 PM" src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/43310446/7aea9e50-b4bb-471c-b0ed-aa0925f0d2ba">
