### PR TITLE
Add Proper Support for Dark Theme

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/Home.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/Home.kt
@@ -79,7 +79,9 @@ fun HomeScreen(
     ) {
 
     Column(
-        modifier = modifier.fillMaxSize()
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.background)
     ) {
 
         val context = LocalContext.current
@@ -169,7 +171,7 @@ fun HomeScreen(
             SearchDisplay.SearchInProgress -> {
                 Box(
                     modifier = Modifier
-                        .background(Color.White)
+                        .background(MaterialTheme.colors.background)
                         .fillMaxSize()
                 )
             }
@@ -304,7 +306,7 @@ fun TutorialListContent(
 
     Surface(
         modifier = modifier.fillMaxSize(),
-        color = Color(0xffEEEEEE)
+        color = MaterialTheme.colors.background
     ) {
 
         Box {

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/Search.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/Search.kt
@@ -1,7 +1,9 @@
 package com.smarttoolfactory.tutorial1_1basics
 
+import android.content.res.Resources.Theme
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,8 +23,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -47,7 +51,7 @@ fun SearchBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(Color.White),
+            .background(MaterialTheme.colors.background),
         verticalAlignment = Alignment.CenterVertically
     ) {
 
@@ -106,8 +110,9 @@ fun SearchTextField(
                         end = 16.dp
                     )
             ),
-        color = Color(0xffF5F5F5),
+        color = MaterialTheme.colors.surface,
         shape = RoundedCornerShape(percent = 50),
+        border = BorderStroke(1.dp, MaterialTheme.colors.onBackground)
     ) {
 
         CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
@@ -123,6 +128,8 @@ fun SearchTextField(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     BasicTextField(
                         value = query,
+                        cursorBrush = SolidColor(MaterialTheme.colors.onBackground),
+                        textStyle = TextStyle(color = MaterialTheme.colors.onBackground),
                         onValueChange = onQueryChange,
                         modifier = Modifier
                             .fillMaxHeight()
@@ -168,7 +175,7 @@ private fun SearchHint(modifier: Modifier = Modifier) {
 
     ) {
         Text(
-            color = Color(0xffBDBDBD),
+            color = MaterialTheme.colors.onSurface,
             text = "Search a Tag or Description",
         )
     }

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/ui/Theme.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/ui/Theme.kt
@@ -1,5 +1,6 @@
 package com.smarttoolfactory.tutorial1_1basics.ui
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
@@ -11,21 +12,30 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorPalette = darkColors(
     primary = purple200,
-    primaryVariant = purple700,
     secondary = teal200,
-    background = Color.White,
+    primaryVariant = purple700,
+    error = Color(0xFFB3261E),
+    background = Color(0xFF1C1B1F),
+    surface = Color(0xFF201F24),
+    onPrimary = Color.Black,
+    onSecondary = Color.White,
+    onBackground = Color(0xFFE6E1E5),
+    onSurface = Color(0xFFE6E1E5),
+    onError = Color.White
 )
 
 private val LightColorPalette = lightColors(
     primary = purple500,
-    primaryVariant = purple700,
     secondary = teal200,
-    background = Color.White,
-    surface = Color.White,
+    primaryVariant = purple700,
+    error = Color(0xFFF2B8B5),
+    surface = Color(0xFFE6E1E5),
+    background = Color(0xFFE6E1E5),
     onPrimary = Color.White,
-    onSecondary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
+    onSecondary = Color.White,
+    onBackground = Color(0xFF201F24),
+    onSurface = Color(0xFF201F24),
+    onError = Color(0xFF601410)
 )
 
 @Composable

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/ui/components/CustomChip.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/ui/components/CustomChip.kt
@@ -41,8 +41,9 @@ fun TutorialChip(modifier: Modifier = Modifier, text: String, color: Color = Col
     Card(
         elevation = 0.dp,
         modifier = modifier,
-        backgroundColor = Color(0xFFE0E0E0),
-        shape = RoundedCornerShape(16.dp)
+        backgroundColor = MaterialTheme.colors.background,
+        shape = RoundedCornerShape(16.dp),
+        border = BorderStroke(1.dp, color = MaterialTheme.colors.onSurface)
     ) {
         Row(
             modifier = Modifier.padding(start = 8.dp, top = 4.dp, end = 8.dp, bottom = 4.dp),
@@ -110,8 +111,9 @@ fun CancelableChip(
     Surface(
         elevation = 0.dp,
         modifier = modifier,
-        color = Color(0xFFE0E0E0),
-        shape = RoundedCornerShape(16.dp)
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colors.background,
+        border = BorderStroke(1.dp, MaterialTheme.colors.onSurface)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/ui/components/TutorialSectionCard.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/ui/components/TutorialSectionCard.kt
@@ -33,7 +33,7 @@ fun TutorialSectionCard(
     expanded: Boolean
 ) {
     Card(
-        elevation = 1.dp,
+        elevation = 1.dp, backgroundColor = MaterialTheme.colors.surface,
         shape = RoundedCornerShape(8.dp)
     ) {
         Box(


### PR DESCRIPTION
### Dark Theme Before & After
| Before  | After |
| :-: | :-:|
| <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/7114c974-888c-45e2-919b-36d07d63e40d" width="400"/> | <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/424c9aca-ae75-4d6a-a99a-16ef58e66c0e" width="400" /> |
| <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/d9d3ad0f-db38-4d2a-b25d-3c3ccdc93fa4" width="400"/> | <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/a93cd356-34cd-4c8f-baa0-5b0434f60247" width="400" /> |
| <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/d04226b5-b7e8-42e9-8542-e7fe914660ab" width="400"/> | <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/fecf31f8-37a8-4e2e-afc4-0ba2b8706972" width="400" /> |


### Current Dark Theme Vs Light Theme

| Dark  | Light |
| :-: | :-:|
| <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/4778f096-252f-4704-9c56-7ac246f59358" width="400"/> | <img src="https://github.com/SmartToolFactory/Jetpack-Compose-Tutorials/assets/83871075/b940aab4-5938-4134-a944-0000ab1bea89" width="400" /> |