### PR TITLE
Small typo fixes for a class name and tutorial documentation in comment text 

### DIFF
--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_13SwipeToDismiss.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter2_material_widgets/Tutorial2_13SwipeToDismiss.kt
@@ -76,7 +76,7 @@ private fun TutorialContent(viewModel: MyViewModel) {
             items(items = usersList.value, key = { user -> user.id }) { user ->
 
                 // https://stackoverflow.com/questions/75040603/is-composes-swipe-to-dismiss-state-always-remember-the-old-item-based-on-id-ev
-                // This is required as expalined in the link stackoverflow link
+                // This is required as explained in the link stackoverflow link
                 val currentItem by rememberUpdatedState(user)
 
                 val dismissState = rememberDismissState(

--- a/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter4_state/Tutorial4_2_4Stability.kt
+++ b/Tutorial1-1Basics/src/main/java/com/smarttoolfactory/tutorial1_1basics/chapter4_state/Tutorial4_2_4Stability.kt
@@ -90,7 +90,7 @@ private fun ComposeScopeSample() {
     }
 
     val stableData by remember {
-        mutableStateOf(StableDataClas(0))
+        mutableStateOf(StableDataClass(0))
     }
 
     Column {
@@ -121,7 +121,7 @@ private fun ComposeScopeSample() {
 data class UnStableDataClass(var value: Int)
 
 // A class with all of its params immutable is Stable
-data class StableDataClas(val value: Int)
+data class StableDataClass(val value: Int)
 
 @Composable
 private fun UnstableComposable(data: UnStableDataClass) {
@@ -141,7 +141,7 @@ private fun UnstableComposable(data: UnStableDataClass) {
 }
 
 @Composable
-private fun StableComposable(data: StableDataClas) {
+private fun StableComposable(data: StableDataClass) {
     SideEffect {
         println("🍏 StableComposable")
     }


### PR DESCRIPTION
Hey, this tutorial is super helpful, I found a couple typos while working through it and just wanted to offer up a quick fix. Thanks, Ben